### PR TITLE
fix: renovate needs to run on this fork

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,12 +186,12 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.8)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     optimist (3.0.1)
     parallel (1.22.1)

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "includeForks": true,
+    "extends": [
+        "github>kuchosauronad0/renovate-config"
+    ]
+}


### PR DESCRIPTION
Renovatebot will open an issue that is continuously updated when an update for
the tracked package mechanisms is detected.

A central configuration repository 'renovate-config' can be provided.

See #4  Currently Travis CI fails because it tries to run on the lowest ruby version that should be supported(2.7.1) while the Gemfile uses a newer version (3.1.2).