### PR TITLE
fix: Use the same version as the Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 dist: focal
-rvm: 2.5.8
+rvm: 3.1.2
 
 cache:
   bundler: true


### PR DESCRIPTION
Currently Travis CI fails because it tries to run on the lowest ruby version that should be supported(2.7.1) while the Gemfile uses a newer version (3.1.2).

Ideally it should run on:

Ruby 2.5 - Puppet 6
Ruby 2.7 - Puppet 7
Ruby 3.1

Yes because why should I not merge this?! TODO: matrix testing